### PR TITLE
Improve SP‑API configuration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,16 @@ npm start
 
 ## Environment Configuration
 
-Create a `.env` file in the project root with the following variables:
+Create a `.env` file in the project root with the following variables (new naming
+used by `amazon-sp-api` v2):
 
 ```
 # Amazon SP-API Credentials
-SP_API_CLIENT_ID=your_client_id
-SP_API_CLIENT_SECRET=your_client_secret
-SP_API_REFRESH_TOKEN=your_refresh_token
-AWS_ACCESS_KEY_ID=your_aws_access_key
-AWS_SECRET_ACCESS_KEY=your_aws_secret_key
+SELLING_PARTNER_APP_CLIENT_ID=your_client_id
+SELLING_PARTNER_APP_CLIENT_SECRET=your_client_secret
+SELLING_PARTNER_REFRESH_TOKEN=your_refresh_token
+AWS_SELLING_PARTNER_ACCESS_KEY_ID=your_aws_access_key
+AWS_SELLING_PARTNER_SECRET_ACCESS_KEY=your_aws_secret_key
 AWS_SELLING_PARTNER_ROLE=your_role_arn
 
 # Region settings
@@ -69,6 +70,9 @@ MARKETPLACE_ID=your_marketplace_id
 # App settings
 PORT=3000
 ```
+
+The application also falls back to the older environment variable names
+(`SP_API_CLIENT_ID`, `SP_API_CLIENT_SECRET`, etc.) for backward compatibility.
 
 ## Usage
 

--- a/test-connection.js
+++ b/test-connection.js
@@ -4,18 +4,20 @@ const logger = require('./src/utils/logger');
 
 async function testConnection() {
   try {
-    logger.info('Testing Amazon SP-API connection with v2 environment variables...');
-    
-    // The library will automatically pick up these environment variables:
-    // - SELLING_PARTNER_APP_CLIENT_ID
-    // - SELLING_PARTNER_APP_CLIENT_SECRET
-    // - SELLING_PARTNER_REFRESH_TOKEN
-    // - AWS_SELLING_PARTNER_ACCESS_KEY_ID
-    // - AWS_SELLING_PARTNER_SECRET_ACCESS_KEY
-    // - AWS_SELLING_PARTNER_ROLE
-    
+    logger.info('Testing Amazon SP-API connection...');
+
+    const credentials = {
+      SELLING_PARTNER_APP_CLIENT_ID: process.env.SELLING_PARTNER_APP_CLIENT_ID || process.env.SP_API_CLIENT_ID,
+      SELLING_PARTNER_APP_CLIENT_SECRET: process.env.SELLING_PARTNER_APP_CLIENT_SECRET || process.env.SP_API_CLIENT_SECRET,
+      AWS_ACCESS_KEY_ID: process.env.AWS_SELLING_PARTNER_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID,
+      AWS_SECRET_ACCESS_KEY: process.env.AWS_SELLING_PARTNER_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY,
+      AWS_SELLING_PARTNER_ROLE: process.env.AWS_SELLING_PARTNER_ROLE
+    };
+
     const spApi = new SellingPartnerAPI({
       region: process.env.SP_API_REGION?.toLowerCase() || 'na',
+      refresh_token: process.env.SELLING_PARTNER_REFRESH_TOKEN || process.env.SP_API_REFRESH_TOKEN,
+      credentials,
       options: {
         debug_log: true
       }


### PR DESCRIPTION
## Summary
- ensure Amazon API service supports both old and new SP‑API env var names
- document required env variables using the current naming
- update connection test script to use the same fallback logic

## Testing
- `node test-connection.js` *(fails: Provide a refresh token or set "only_grantless_operations" option to true)*
- `node src/index.js` *(server starts)*

------
https://chatgpt.com/codex/tasks/task_e_6886295cbb1883268a57248366004072